### PR TITLE
[ESN-2555] Use dl tag to list key value pairs in composite fields

### DIFF
--- a/ckanext/composite/templates/scheming/display_snippets/composite.html
+++ b/ckanext/composite/templates/scheming/display_snippets/composite.html
@@ -3,8 +3,9 @@
 {% set name_list = h.composite_get_name_list(field.subfields) %}
 {% set composite_dict = h.composite_get_as_dict(data[field.field_name]) %}
 
+<dl>
 {% for key in name_list%}
-  {% if composite_dict[key]|length >0 %}
+  {% if composite_dict[key]|length > 0 %}
     {% if choices_dict[key]|length > 0 %}
       {% if h.composite_is_list(composite_dict[key]) %}
         {%- set labels = [] -%}
@@ -18,17 +19,23 @@
     {% else %}
       {% set value = composite_dict[key] %}
     {% endif %}
-    <b>{{ label_dict[key] }}:</b>
-    {% if value is iterable and value is not string %}
-      {{ value | reject('equalto', '') | join(', ') }}
-    {% else %}
-      {% if h.composite_is_mail(value) %}
-        {{ value.split('@')[0] }}<span style="display:none">foo</span>(at){{ value.split('@')[1] }}
-      {% else %}
-        {{ value }}
-      {% endif %}
-    {% endif %}
+    <div>
+      <dt>{{ label_dict[key] }}:</dt>
+      <dd>
+        {% if value is iterable and value is not string %}
+          {% for item in value %}
+            {{ item }}<br/>
+          {% endfor %}
+        {% else %}
+          {% if h.composite_is_mail(value) %}
+            {{ value.split('@')[0] }}<span style="display:none">foo</span>(at){{ value.split('@')[1] }}
+          {% else %}
+            {{ value }}
+          {% endif %}
+        {% endif %}
+      </dd>
+    </div>
     <br>
   {% endif %}
 {% endfor %}
-
+</dl>


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2555](https://opengovinc.atlassian.net/browse/ESN-2555)

## Description
<!--- Describe these changes in detail --->
This PR updates the display template for composite fields. To improve the display of key value pairs the HTML tag `dl` is used.